### PR TITLE
Add a NoOp encoder for performance reasons

### DIFF
--- a/redis-to-cloud-cache/session-state/spring-session-boot-json/redis/src/main/java/bootjson/session/redis/config/SecurityConfig.java
+++ b/redis-to-cloud-cache/session-state/spring-session-boot-json/redis/src/main/java/bootjson/session/redis/config/SecurityConfig.java
@@ -13,12 +13,20 @@ language governing permissions and limitations under the License.*/
 package bootjson.session.redis.config;
 
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Bean
+	public PasswordEncoder passwordEncoder(){
+		return NoOpPasswordEncoder.getInstance();
+	}
 
 	// @formatter:off
 	@Override


### PR DESCRIPTION
- The default Bcrypt encoder uses up a lot of CPU when this app is under
  heavy (jmeter) load. Avoiding this allows more pressure to be placed
  on the backend.

Authored-by: Jens Deppe <jdeppe@pivotal.io>